### PR TITLE
Supports parallel assignment

### DIFF
--- a/lib/pry-byetypo/session/populate_history.rb
+++ b/lib/pry-byetypo/session/populate_history.rb
@@ -14,6 +14,8 @@ module Session
     end
 
     def call
+      return unless is_assignement_variables?
+
       store.transaction do
         store.abort unless variables_to_store
 
@@ -29,11 +31,27 @@ module Session
     end
 
     def variables_to_store
-      @variables_to_store ||= last_cmd.split("=").first.strip.split(", ")
+      @variables_to_store ||= last_cmd.split("=").first.strip.split(",")
     end
 
     def last_cmd
       binding.eval_string.strip
+    end
+
+    # Returns true if the last command seems to be an assignment of variables, false otherwise.
+    #
+    # Examples
+    #
+    #   is_assignment_variables?("user_last, user_first = User.last, User.first")
+    #   # => true
+    #
+    #   is_assignment_variables?("user_last = User.last")
+    #   # => true
+    #
+    #   is_assignment_variables?("user_last")
+    #   # => false
+    def is_assignement_variables?
+      last_cmd.include?("=")
     end
   end
 end

--- a/spec/session/populate_history_spec.rb
+++ b/spec/session/populate_history_spec.rb
@@ -11,12 +11,38 @@ RSpec.describe Session::PopulateHistory do
     allow(PStore).to receive(:new).and_return(store)
     store.transaction { store[pry_instance_uid] = [] }
     allow(pry).to receive(:binding_stack).and_return([pry_instance_uid])
-    allow(pry).to receive(:eval_string).and_return("user_last, user_first = User.last, User,first")
+    allow(pry).to receive(:eval_string).and_return(variables)
   end
 
-  it "populates the table of the current pry instance" do
-    expect(store.transaction { store[pry_instance_uid] }).to eq([])
-    subject
-    expect(store.transaction { store[pry_instance_uid] }).to eq(["user_last", "user_first"])
+  context "given variable who is not eligible to be stored" do
+    let(:variables) { "variable" }
+
+    it "does not populate the table" do
+      expect(store.transaction { store[pry_instance_uid] }).to eq([])
+      subject
+      expect(store.transaction { store[pry_instance_uid] }).to eq([])
+    end
+  end
+
+  context "given a variable who is eligible to be stored" do
+    context "given a regular variable assignement" do
+      let(:variables) { "user_last = User.last" }
+
+      it "populates the table of the current pry instance" do
+        expect(store.transaction { store[pry_instance_uid] }).to eq([])
+        subject
+        expect(store.transaction { store[pry_instance_uid] }).to eq(["user_last"])
+      end
+    end
+
+    context "given parallel variables assignement" do
+      let(:variables) { "user_last,user_first = User.last, User,first" }
+
+      it "populates the table of the current pry instance" do
+        expect(store.transaction { store[pry_instance_uid] }).to eq([])
+        subject
+        expect(store.transaction { store[pry_instance_uid] }).to eq(["user_last", "user_first"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix https://github.com/morissetcl/pry-byetypo/issues/29

Now we support parallel assignment:

```ruby
variable1, variable2 = 1, 2
```

will be stored as

```
[variable1, variable2]
```

Additionally we fixed a small bug. 
We used to store any variables even if it was not an assignment variable.