### PR TITLE
Make this plugin ORM agnostic

### DIFF
--- a/lib/pry-byetypo/exceptions/active_record/base.rb
+++ b/lib/pry-byetypo/exceptions/active_record/base.rb
@@ -7,10 +7,6 @@ module Exceptions
     class Base < ExceptionsBase
       private
 
-      def corrected_word
-        @corrected_word ||= spell_checker(associations_dictionary).correct(unknown_from_exception).first
-      end
-
       def corrected_cmd
         @corrected_cmd ||= last_cmd.gsub(/\b#{unknown_from_exception}\b/, corrected_word)
       end
@@ -19,7 +15,7 @@ module Exceptions
         exception.to_s.match(exception_regexp)[1]
       end
 
-      def associations_dictionary
+      def dictionary
         @associations_dictionary ||= store.transaction { |s| s["associations"] }
       end
     end

--- a/lib/pry-byetypo/exceptions/active_record/uninitialized_constant.rb
+++ b/lib/pry-byetypo/exceptions/active_record/uninitialized_constant.rb
@@ -1,25 +1,21 @@
 # frozen_string_literal: true
 
-require_relative "../exceptions_base"
+require_relative "base"
 
 module Exceptions
-  module NameError
-    class UninitializedConstant < ExceptionsBase
+  module ActiveRecord
+    class UninitializedConstant < Base
       private
 
       def unknown_from_exception
         exception.to_s.split.last
       end
 
-      def corrected_word
-        @corrected_word ||= spell_checker(ar_models_dictionary).correct(unknown_from_exception).first
-      end
-
       def corrected_cmd
         @corrected_cmd ||= last_cmd.gsub(unknown_from_exception, corrected_word)
       end
 
-      def ar_models_dictionary
+      def dictionary
         @ar_models_dictionary ||= store.transaction { |s| s["active_record_models"] }
       end
     end

--- a/lib/pry-byetypo/exceptions/exceptions_base.rb
+++ b/lib/pry-byetypo/exceptions/exceptions_base.rb
@@ -29,7 +29,11 @@ class ExceptionsBase < Base
     @pry = pry
   end
 
-  def spell_checker(dictionary)
+  def corrected_word
+    @corrected_word ||= spell_checker.correct(unknown_from_exception).first
+  end
+
+  def spell_checker
     DidYouMean::SpellChecker.new(dictionary: dictionary)
   end
 

--- a/lib/pry-byetypo/exceptions/name_error/handler.rb
+++ b/lib/pry-byetypo/exceptions/name_error/handler.rb
@@ -2,7 +2,7 @@
 
 require_relative "../exceptions_base"
 require_relative "../../constants/errors"
-require_relative "uninitialized_constant"
+require_relative "../active_record/uninitialized_constant"
 require_relative "undefined_variable"
 
 module Exceptions
@@ -21,7 +21,7 @@ module Exceptions
       def call
         case exception.message
         in /#{Constants::Errors::UNINITIALIZED_CONSTANT}/
-          UninitializedConstant.call(output, exception, pry)
+          ActiveRecord::UninitializedConstant.call(output, exception, pry)
         in /#{Constants::Errors::UNDEFINED_VARIABLE}/
           UndefinedVariable.call(output, exception, pry)
         else

--- a/lib/pry-byetypo/exceptions/name_error/undefined_variable.rb
+++ b/lib/pry-byetypo/exceptions/name_error/undefined_variable.rb
@@ -7,10 +7,6 @@ module Exceptions
     class UndefinedVariable < ExceptionsBase
       private
 
-      def corrected_word
-        @corrected_word ||= spell_checker(session_dictionary).correct(unknown_from_exception).first
-      end
-
       def corrected_cmd
         @corrected_cmd ||= last_cmd.gsub(/\b#{unknown_from_exception}\b/, corrected_word)
       end
@@ -19,7 +15,7 @@ module Exceptions
         exception.to_s.match(exception_regexp)[1]
       end
 
-      def session_dictionary
+      def dictionary
         @session_dictionary ||= store.transaction { |s| s[pry_instance_uid] }
       end
 

--- a/lib/pry-byetypo/setup/application_dictionary.rb
+++ b/lib/pry-byetypo/setup/application_dictionary.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "checks/database_url"
-require_relative "checks/database_pool"
-require_relative "store"
 require_relative "../base"
-
+require_relative "store"
+require_relative "dictionary/active_record"
 require "pstore"
 
 module Setup
@@ -16,7 +14,7 @@ module Setup
     end
 
     def call
-      establish_db_connection
+      Setup::Dictionary::ActiveRecord.initialize! if defined?(ActiveRecord)
       populate_store
     end
 
@@ -24,78 +22,14 @@ module Setup
 
     attr_reader :binding
 
-    SEVEN_DAYS = 604800
-
     def populate_store
-      store.transaction do
-        # Create a table with unique instance identifier information to store variables history.
-        store[pry_instance_uid] = []
-        store.commit unless staled_store?
-
-        store["active_record_models"] = populate_active_record_models_dictionary
-        store["associations"] = populate_associations
-        store["synced_at"] = Time.now
-      end
-    end
-
-    def establish_db_connection
-      configuration_checks
-      ActiveRecord::Base.establish_connection(development_database_config)
-    end
-
-    def populate_active_record_models_dictionary
-      Zeitwerk::Loader.eager_load_all
-      ActiveRecord::Base.descendants.map { |model| format_active_record_model(model) }.flatten
-    end
-
-    def populate_associations
-      table_names = ActiveRecord::Base.connection.tables
-      singularize_table_names = table_names.map { |a| a.chop }
-      table_names.zip(singularize_table_names).flatten
-    end
-
-    def configuration_checks
-      Setup::Checks::DatabaseUrl.check(development_database_config, logger)
-      Setup::Checks::DatabasePool.check(development_database_config, logger)
-    end
-
-    def database_config
-      YAML.safe_load(File.read(database_config_path), aliases: true)
-    end
-
-    def development_database_config
-      @development_database_config ||= database_config["development"]
-    end
-
-    # This method takes an ActiveRecord model as an argument and formats its name and module information.
-    # If the model is within a module namespace, it returns an array containing the model's name and an array of its modules.
-    # If the model is not within a module, it returns just the model's name as a string.
-    def format_active_record_model(model)
-      modules = model.name.split("::")
-      return model.name, modules if modules.count > 1
-
-      model.name
-    end
-
-    # By default we update the store every week.
-    # TODO: Make it configurable
-    def staled_store?
-      return true if store["synced_at"].nil?
-
-      (store["synced_at"] + SEVEN_DAYS) <= Time.now
+      # Create a table with unique instance identifier information to store variables history.
+      store.transaction { store[pry_instance_uid] = [] }
     end
 
     # Use the binding identifier as pry instance uid.
     def pry_instance_uid
       binding.to_s
-    end
-
-    def logger
-      @logger = Logger.new($stdout)
-    end
-
-    def database_config_path
-      ENV["DB_CONFIG_PATH"] || "./config/database.yml"
     end
   end
 end

--- a/lib/pry-byetypo/setup/dictionary/active_record.rb
+++ b/lib/pry-byetypo/setup/dictionary/active_record.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative "../checks/database_url"
+require_relative "../checks/database_pool"
+require_relative "../store"
+
+require "pstore"
+
+module Setup
+  module Dictionary
+    class ActiveRecord
+      class << self
+        include Store
+
+        def initialize!
+          establish_db_connection
+          populate_store
+        end
+
+        private
+
+        def populate_store
+          store.transaction do
+            store.commit unless staled_store?
+
+            store["active_record_models"] = populate_active_record_models_dictionary
+            store["associations"] = populate_associations
+            store["synced_at"] = Time.now
+          end
+        end
+
+        def establish_db_connection
+          configuration_checks
+          ::ActiveRecord::Base.establish_connection(development_database_config)
+        end
+
+        def populate_active_record_models_dictionary
+          Zeitwerk::Loader.eager_load_all
+          ::ActiveRecord::Base.descendants.map { |model| format_active_record_model(model) }.flatten
+        end
+
+        def populate_associations
+          table_names = ::ActiveRecord::Base.connection.tables
+          singularize_table_names = table_names.map { |a| a.chop }
+          table_names.zip(singularize_table_names).flatten
+        end
+
+        # This method takes an ActiveRecord model as an argument and formats its name and module information.
+        # If the model is within a module namespace, it returns an array containing the model's name and an array of its modules.
+        # If the model is not within a module, it returns just the model's name as a string.
+        def format_active_record_model(model)
+          modules = model.name.split("::")
+          return model.name, modules if modules.count > 1
+
+          model.name
+        end
+
+        def development_database_config
+          @development_database_config ||= database_config["development"]
+        end
+
+        def configuration_checks
+          Setup::Checks::DatabaseUrl.check(development_database_config, logger)
+          Setup::Checks::DatabasePool.check(development_database_config, logger)
+        end
+
+        def database_config
+          YAML.safe_load(File.read(database_config_path), aliases: true)
+        end
+
+        def logger
+          @logger = Logger.new($stdout)
+        end
+
+        def database_config_path
+          ENV["DB_CONFIG_PATH"] || "./config/database.yml"
+        end
+      end
+    end
+  end
+end

--- a/lib/pry-byetypo/setup/store.rb
+++ b/lib/pry-byetypo/setup/store.rb
@@ -1,6 +1,7 @@
 module Setup
   module Store
     DEFAULT_STORE_PATH = "byetypo_dictionary.pstore"
+    SEVEN_DAYS = 604800
 
     def store
       @store ||= PStore.new(store_path)
@@ -8,6 +9,14 @@ module Setup
 
     def store_path
       ENV["BYETYPO_STORE_PATH"] || DEFAULT_STORE_PATH
+    end
+
+    # By default we update the store every week.
+    # TODO: Make it configurable
+    def staled_store?
+      return true if store["synced_at"].nil?
+
+      (store["synced_at"] + SEVEN_DAYS) <= Time.now
     end
   end
 end

--- a/spec/exceptions/active_record/uninitialized_constant_spec.rb
+++ b/spec/exceptions/active_record/uninitialized_constant_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Exceptions::NameError::UninitializedConstant do
+RSpec.describe Exceptions::ActiveRecord::UninitializedConstant do
   subject { described_class.call(output, exception, pry) }
 
   let(:output) { Pry::Output.new(pry) }

--- a/spec/exceptions/name_error/handler_spec.rb
+++ b/spec/exceptions/name_error/handler_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Exceptions::NameError::Handler do
       let(:exception) { NameError.new("uninitialized constant Use") }
 
       it "calls Exceptions::NameError::UninitializedConstant" do
-        expect(Exceptions::NameError::UninitializedConstant).to receive(:call).with(output, exception, pry)
+        expect(Exceptions::ActiveRecord::UninitializedConstant).to receive(:call).with(output, exception, pry)
         subject
       end
     end

--- a/spec/setup/application_dictionary_spec.rb
+++ b/spec/setup/application_dictionary_spec.rb
@@ -9,85 +9,38 @@ class PostgreSQLAdapter
   end
 end
 
-class User; end
-
-module Account
-  class Deal; end
-end
-
 RSpec.describe Setup::ApplicationDictionary do
   subject { described_class.call(pry_instance_uid) }
 
   let(:pry_instance_uid) { 1234 }
   let(:store) { PStore.new(ENV["BYETYPO_STORE_PATH"]) }
-  let(:current_time) { Time.new(2024, 11, 1, 15, 25, 0, "+09:00") }
 
-  before do
-    allow(PStore).to receive(:new).and_return(store)
-    # Reset store
-    store.transaction do
-      store.delete(pry_instance_uid)
-      store.delete("active_record_models")
-      store.delete("associations")
-      store.delete("synced_at")
+  before { allow(PStore).to receive(:new).and_return(store) }
+
+  context "given ActiveRecord defined" do
+    before do
+      store.transaction do
+        store.delete(pry_instance_uid)
+        store.delete("active_record_models")
+        store.delete("associations")
+        store.delete("synced_at")
+      end
+
+      allow(Zeitwerk::Loader).to receive(:eager_load_all)
+      allow(ActiveRecord::Base).to receive(:establish_connection)
+      allow(ActiveRecord::Base).to receive(:connection).and_return(PostgreSQLAdapter.new)
     end
 
-    allow(Zeitwerk::Loader).to receive(:eager_load_all)
-    allow(ActiveRecord::Base).to receive(:establish_connection)
-    allow(ActiveRecord::Base).to receive(:connection).and_return(PostgreSQLAdapter.new)
-    allow(ActiveRecord::Base).to receive(:descendants).and_return([User, Account::Deal])
-  end
-
-  context "given a staled store" do
-    it "calls checks" do
-      expect(Setup::Checks::DatabaseUrl).to receive(:check)
-      expect(Setup::Checks::DatabasePool).to receive(:check)
+    it "calls Setup::Dictionary::ActiveRecord" do
+      expect(Setup::Dictionary::ActiveRecord).to receive(:initialize!).and_return(nil)
 
       subject
     end
 
-    it "populates stores with associations" do
+    it "create the `pry_instance_uid` table" do
       subject
 
-      expect(store.transaction { store["associations"] }).to eq(["users", "user", "accounts", "account", "deals", "deal"])
-    end
-
-    it "populates stores with active_record_models" do
-      subject
-
-      expect(store.transaction { store["active_record_models"] }).to eq(["User", "Account::Deal", "Account", "Deal"])
-    end
-
-    it "populates stores with synced_at" do
-      allow(Time).to receive(:now).and_return(current_time)
-
-      subject
-
-      expect(store.transaction { store["synced_at"] }).to eq(current_time)
-    end
-  end
-
-  context "given a staled store" do
-    before { store.transaction { store["synced_at"] = current_time } }
-
-    it "populates stores with synced_at" do
-      allow(Time).to receive(:now).and_return(current_time)
-
-      subject
-
-      expect(store.transaction { store["synced_at"] }).to eq(current_time)
-    end
-
-    it "does not populates stores with active_record_models" do
-      subject
-
-      expect(store.transaction { store["active_record_models"] }).to be_nil
-    end
-
-    it "does not populates stores with associations" do
-      subject
-
-      expect(store.transaction { store["associations"] }).to be_nil
+      expect(store.transaction { store[pry_instance_uid.to_s] }).to eq([])
     end
   end
 end

--- a/spec/setup/dictionary/active_record_spec.rb
+++ b/spec/setup/dictionary/active_record_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "zeitwerk"
+require "active_record"
+
+class PostgreSQLAdapter
+  def tables
+    ["users", "accounts", "deals"]
+  end
+end
+
+class User; end
+
+module Account
+  class Deal; end
+end
+
+RSpec.describe Setup::Dictionary::ActiveRecord do
+  subject { described_class.initialize! }
+
+  let(:pry_instance_uid) { 1234 }
+  let(:store) { PStore.new(ENV["BYETYPO_STORE_PATH"]) }
+  let(:current_time) { Time.new(2024, 11, 1, 15, 25, 0, "+09:00") }
+
+  before do
+    allow(PStore).to receive(:new).and_return(store)
+    # Reset store
+    store.transaction do
+      store.delete(pry_instance_uid)
+      store.delete("active_record_models")
+      store.delete("associations")
+      store.delete("synced_at")
+    end
+
+    allow(Zeitwerk::Loader).to receive(:eager_load_all)
+    allow(ActiveRecord::Base).to receive(:establish_connection)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(PostgreSQLAdapter.new)
+    allow(ActiveRecord::Base).to receive(:descendants).and_return([User, Account::Deal])
+  end
+
+  context "given a staled store" do
+    it "calls checks" do
+      expect(Setup::Checks::DatabaseUrl).to receive(:check)
+      expect(Setup::Checks::DatabasePool).to receive(:check)
+
+      subject
+    end
+
+    it "populates stores with associations" do
+      subject
+
+      expect(store.transaction { store["associations"] }).to eq(["users", "user", "accounts", "account", "deals", "deal"])
+    end
+
+    it "populates stores with active_record_models" do
+      subject
+
+      expect(store.transaction { store["active_record_models"] }).to eq(["User", "Account::Deal", "Account", "Deal"])
+    end
+
+    it "populates stores with synced_at" do
+      allow(Time).to receive(:now).and_return(current_time)
+
+      subject
+
+      expect(store.transaction { store["synced_at"] }).to eq(current_time)
+    end
+  end
+
+  context "given a staled store" do
+    before { store.transaction { store["synced_at"] = current_time } }
+
+    it "populates stores with synced_at" do
+      allow(Time).to receive(:now).and_return(current_time)
+
+      subject
+
+      expect(store.transaction { store["synced_at"] }).to eq(current_time)
+    end
+
+    it "does not populates stores with active_record_models" do
+      subject
+
+      expect(store.transaction { store["active_record_models"] }).to be_nil
+    end
+
+    it "does not populates stores with associations" do
+      subject
+
+      expect(store.transaction { store["associations"] }).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fix https://github.com/morissetcl/pry-byetypo/issues/25

We have been closely connected with ActiveRecord until now. In case this ORM is not defined, we will only proceed to populate the session table of the dictionary.
