### PR TITLE
Ensure that the store is populated even if previous step fails

### DIFF
--- a/lib/pry-byetypo/setup/application_dictionary.rb
+++ b/lib/pry-byetypo/setup/application_dictionary.rb
@@ -15,6 +15,7 @@ module Setup
 
     def call
       Setup::Dictionary::ActiveRecord.initialize! if defined?(ActiveRecord)
+    ensure
       populate_store
     end
 


### PR DESCRIPTION
When the `Setup::Dictionary::ActiveRecord` step fail for some reasons we don't populate the store.
It should works anyway as this step does not require activerecord.