### PR TITLE
Fix array methods

### DIFF
--- a/lib/pry-byetypo/exceptions/no_method_error.rb
+++ b/lib/pry-byetypo/exceptions/no_method_error.rb
@@ -15,7 +15,7 @@ module Exceptions
     end
 
     def dictionary
-      eval(klass).methods.map(&:to_s) # rubocop:disable Security/Eval
+      eval(infer_klass).methods.map(&:to_s) # rubocop:disable Security/Eval
     end
 
     def exception_regexp
@@ -23,7 +23,17 @@ module Exceptions
     end
 
     def klass
-      exception.to_s.match(/for\s+(.*?):\w*$/)[1]
+      exception_without_class_module = exception.to_s.gsub(":Class", "")
+      exception_without_class_module.split.last
+    end
+
+    # [].methods and Array.methods have a different output.
+    # Array class is a part of the Ruby core library while `[]` is an instance of the Array class.
+    # When calling [].methods, we inspect the methods available to instances of the Array class, including those inherited from its class and ancestors.
+    def infer_klass
+      return klass if klass != "Array"
+
+      "[]"
     end
   end
 end

--- a/spec/exceptions/no_method_error_spec.rb
+++ b/spec/exceptions/no_method_error_spec.rb
@@ -7,16 +7,30 @@ RSpec.describe Exceptions::NoMethodError do
 
   let(:output) { Pry::Output.new(pry) }
   let(:pry) { Pry.new(output: StringIO.new) }
-  let(:exception) { NoMethodError.new("undefined method `ancestrs' for User:Class") }
-  let(:last_cmd) { "User.ancestrs" }
-  let(:corrected_cmd) { "User.ancestors" }
 
   describe "#call" do
     before { allow(Pry).to receive(:line_buffer).and_return([last_cmd]) }
 
-    it "outputs a corrected command and runs it" do
-      expect(pry).to receive(:eval).with(corrected_cmd)
-      subject
+    context "given an undefined method for a model" do
+      let(:last_cmd) { "User.ancestrs" }
+      let(:exception) { NoMethodError.new("undefined method `ancestrs' for User:Class") }
+      let(:corrected_cmd) { "User.ancestors" }
+
+      it "outputs a corrected command and runs it" do
+        expect(pry).to receive(:eval).with(corrected_cmd)
+        subject
+      end
+    end
+
+    context "given an undefined method for a built in class" do
+      let(:last_cmd) { "[1].firsst" }
+      let(:exception) { NoMethodError.new("undefined method `firsst' for an instance of Array") }
+      let(:corrected_cmd) { "[1].first" }
+
+      it "outputs a corrected command and runs it" do
+        expect(pry).to receive(:eval).with(corrected_cmd)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
Before
```
[1] pry(main)> ["a", "b"].firs
(pry) output error: #<NoMethodError: undefined method `[]' for nil>
```

After
```
[1] pry(main)> ["a", "b"].firs
E, [2024-03-16T15:24:53.746943 #10198] ERROR -- : undefined method `firs' for an instance of Array
I, [2024-03-16T15:24:53.747057 #10198]  INFO -- : Running: ["a", "b"].first
=> "a"
```
