### PR TITLE
Does not correct error from code execution

### DIFF
--- a/lib/pry-byetypo/exceptions/exceptions_base.rb
+++ b/lib/pry-byetypo/exceptions/exceptions_base.rb
@@ -29,7 +29,11 @@ class ExceptionsBase < Base
   end
 
   def can_correct?
-    dictionary && corrected_word
+    error_from_typo? && dictionary && corrected_word
+  end
+
+  def error_from_typo?
+    last_cmd.include?(unknown_from_exception)
   end
 
   def corrected_word

--- a/spec/exceptions/no_method_error_spec.rb
+++ b/spec/exceptions/no_method_error_spec.rb
@@ -32,5 +32,15 @@ RSpec.describe Exceptions::NoMethodError do
         subject
       end
     end
+
+    context "given an undefined method error not linked to a REPL typo" do
+      let(:last_cmd) { "UserAccount.perform(user)" }
+      let(:exception) { NoMethodError.new("undefined method `is_loaded?' for Account") }
+
+      it "does not try to correct the last command" do
+        expect(Pry::ExceptionHandler).to receive(:handle_exception)
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Don't try to autocorrect error from executed code. Just try to make it if there is a typo from the REPL.